### PR TITLE
Wrapping title in SafeArea widget

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -49,13 +49,15 @@ class _homeState extends State<home> {
                 child: Container(
                   child: Padding(
                     padding: const EdgeInsets.all(20.0),
-                    child: Text(
-                      widget._sudo ? "!Sudo Mode!" : "Shuffle Cipher",
-                      style: GoogleFonts.bebasNeue(
-                        fontSize: 44,
-                        fontWeight: FontWeight.bold,
-                        letterSpacing: 3,
-                        color: Colors.cyan,
+                    child: SafeArea(
+                      child: Text(
+                        widget._sudo ? "!Sudo Mode!" : "Shuffle Cipher",
+                        style: GoogleFonts.bebasNeue(
+                          fontSize: 44,
+                          fontWeight: FontWeight.bold,
+                          letterSpacing: 3,
+                          color: Colors.cyan,
+                        ),
                       ),
                     ),
                   ),


### PR DESCRIPTION
# Description

- Wrap title text in a SafeArea widget to prevent clipping due to device notches, status bar, etc

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
