### PR TITLE
Adding empty input validation for Cipher Operation

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -559,6 +559,9 @@ class _homeState extends State<home> {
       );
 
   Future<String> _callCipherOperation(String input) async {
+    if (input.trim() == "") {
+      return "";
+    }
     String password_line = "";
     String result = "";
     String output = await _doCiphering(input);


### PR DESCRIPTION
# Description

- Add empty input validation for Cipher operation.
- This prevents empty input("") or spaces("  ") from being accepted as cipherable text.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
